### PR TITLE
Remove Context Aware Attributes

### DIFF
--- a/Lettuce.Log.Core/Lettuce.Log.Core.csproj
+++ b/Lettuce.Log.Core/Lettuce.Log.Core.csproj
@@ -7,7 +7,7 @@
     <Title>Lettuce.Log.Core</Title>
     <Authors>Lettuce Studios</Authors>
     <Description>The core of the Lettuce Logging System to allow for destinations and formatting</Description>
-    <Version>3.1.0</Version>
+    <Version>4.0.0</Version>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <PackageReadmeFile>README.md</PackageReadmeFile>
   </PropertyGroup>

--- a/Lettuce.Log.Core/Log.cs
+++ b/Lettuce.Log.Core/Log.cs
@@ -1,4 +1,3 @@
-using System.Runtime.CompilerServices;
 using System;
 
 namespace Lettuce.Log.Core {

--- a/Lettuce.Log.Core/Log.cs
+++ b/Lettuce.Log.Core/Log.cs
@@ -9,7 +9,7 @@ namespace Lettuce.Log.Core {
         /// <summary>
         /// Default template used for the lazy initialized logger
         /// </summary>
-        public const string DEFAULT_TEMPLATE = "{Level} ({File}/{Method} at {Line}) {Message}";
+        public const string DEFAULT_TEMPLATE = "{Level} {Message}";
 
         /// <summary>
         /// The wrapped <see cref="Logger"/>
@@ -37,55 +37,34 @@ namespace Lettuce.Log.Core {
         }
 
         /// <inheritdoc cref="Logger.Verbose"/>
-        public static void Verbose(string message, 
-            [CallerMemberName]string methodName = "", 
-            [CallerFilePath]string filePath = "",
-            [CallerLineNumber]int lineNumber = -1)
-            => LogMessage(LogEventLevel.VERBOSE, message, methodName, filePath, lineNumber);
+        public static void Verbose(string message, ILogFormatter[]? dynamicFormats = null)
+            => LogMessage(LogEventLevel.VERBOSE, message, dynamicFormats);
         
         /// <inheritdoc cref="Logger.Debug"/>
-        public static void Debug(string message, 
-            [CallerMemberName]string methodName = "", 
-            [CallerFilePath]string filePath = "",
-            [CallerLineNumber]int lineNumber = -1)
-            => LogMessage(LogEventLevel.DEBUG, message, methodName, filePath, lineNumber);
+        public static void Debug(string message, ILogFormatter[]? dynamicFormats = null)
+            => LogMessage(LogEventLevel.DEBUG, message, dynamicFormats);
         
         /// <inheritdoc cref="Logger.Info"/>
-        public static void Info(string message, 
-            [CallerMemberName]string methodName = "", 
-            [CallerFilePath]string filePath = "",
-            [CallerLineNumber]int lineNumber = -1)
-            => LogMessage(LogEventLevel.INFORMATION, message, methodName, filePath, lineNumber);
+        public static void Info(string message, ILogFormatter[]? dynamicFormats = null)
+            => LogMessage(LogEventLevel.INFORMATION, message, dynamicFormats);
         
         /// <inheritdoc cref="Logger.Warning"/>
-        public static void Warning(string message, 
-            [CallerMemberName]string methodName = "", 
-            [CallerFilePath]string filePath = "",
-            [CallerLineNumber]int lineNumber = -1)
-            => LogMessage(LogEventLevel.WARNING, message, methodName, filePath, lineNumber);
+        public static void Warning(string message, ILogFormatter[]? dynamicFormats = null)
+            => LogMessage(LogEventLevel.WARNING, message, dynamicFormats);
         
         /// <inheritdoc cref="Logger.Error"/>
-        public static void Error(string message, 
-            [CallerMemberName]string methodName = "", 
-            [CallerFilePath]string filePath = "",
-            [CallerLineNumber]int lineNumber = -1)
-            => LogMessage(LogEventLevel.ERROR, message, methodName, filePath, lineNumber);
+        public static void Error(string message, ILogFormatter[]? dynamicFormats = null)
+            => LogMessage(LogEventLevel.ERROR, message, dynamicFormats);
         
         /// <inheritdoc cref="Logger.Fatal"/>
-        public static void Fatal(string message, 
-            [CallerMemberName]string methodName = "", 
-            [CallerFilePath]string filePath = "",
-            [CallerLineNumber]int lineNumber = -1)
-            => LogMessage(LogEventLevel.FATAL, message, methodName, filePath, lineNumber);
+        public static void Fatal(string message, ILogFormatter[]? dynamicFormats = null)
+            => LogMessage(LogEventLevel.FATAL, message, dynamicFormats);
 
 
         /// <inheritdoc cref="Logger.LogMessage"/>
-        public static void LogMessage(LogEventLevel logLevel, string message,
-            [CallerMemberName]string methodName = "", 
-            [CallerFilePath]string filePath = "",
-            [CallerLineNumber]int lineNumber = -1)
+        public static void LogMessage(LogEventLevel logLevel, string message, ILogFormatter[]? dynamicFormats = null)
         {
-            Logger.LogMessage(logLevel, message, filePath, methodName, lineNumber);
+            Logger.LogMessage(logLevel, message, dynamicFormats);
         }
     }
 }

--- a/Lettuce.Log.Core/Logger.cs
+++ b/Lettuce.Log.Core/Logger.cs
@@ -1,6 +1,4 @@
-using System.Runtime.CompilerServices;
 using System;
-using System.IO;
 using System.Collections.Generic;
 
 namespace Lettuce.Log.Core {

--- a/Lettuce.Log.Core/Logger.cs
+++ b/Lettuce.Log.Core/Logger.cs
@@ -61,71 +61,57 @@ namespace Lettuce.Log.Core {
         /// Logs a <see cref="LogEventLevel.VERBOSE"/> message with context info
         /// </summary>
         /// <param name="message">the message to log</param>
-        /// <param name="callingFile">the calling file via <see cref="CallerFilePathAttribute"/></param>
-        /// <param name="callingMethod">the calling method via <see cref="CallerMemberNameAttribute"/></param>
-        /// <param name="lineNumber">the calling line number via <see cref="CallerLineNumberAttribute"/></param>
-        public void Verbose(string message, [CallerFilePath] string callingFile = "", [CallerMemberName] string callingMethod = "", [CallerLineNumber] int lineNumber = -1)
-            => LogMessage(LogEventLevel.VERBOSE, message, callingFile, callingMethod, lineNumber);
+        /// <param name="dynamicFormats">(optional) the list of <see cref="ILogFormatter"/> to use for log message formatting that are not a part of the logger</param>
+        public void Verbose(string message, ILogFormatter[]? dynamicFormats = null)
+            => LogMessage(LogEventLevel.VERBOSE, message, dynamicFormats);
         
         /// <summary>
         /// Logs a <see cref="LogEventLevel.DEBUG"/> message with context info
         /// </summary>
         /// <param name="message">the message to log</param>
-        /// <param name="callingFile">the calling file via <see cref="CallerFilePathAttribute"/></param>
-        /// <param name="callingMethod">the calling method via <see cref="CallerMemberNameAttribute"/></param>
-        /// <param name="lineNumber">the calling line number via <see cref="CallerLineNumberAttribute"/></param>
-        public void Debug(string message, [CallerFilePath]string callingFile = "", [CallerMemberName]string callingMethod = "", [CallerLineNumber]int lineNumber = -1)
-            => LogMessage(LogEventLevel.DEBUG, message, callingFile, callingMethod, lineNumber);
+        /// <param name="dynamicFormats">(optional) the list of <see cref="ILogFormatter"/> to use for log message formatting that are not a part of the logger</param>
+        public void Debug(string message, ILogFormatter[]? dynamicFormats = null)
+            => LogMessage(LogEventLevel.DEBUG, message, dynamicFormats);
         
         /// <summary>
         /// Logs a <see cref="LogEventLevel.INFORMATION"/> message with context info
         /// </summary>
         /// <param name="message">the message to log</param>
-        /// <param name="callingFile">the calling file via <see cref="CallerFilePathAttribute"/></param>
-        /// <param name="callingMethod">the calling method via <see cref="CallerMemberNameAttribute"/></param>
-        /// <param name="lineNumber">the calling line number via <see cref="CallerLineNumberAttribute"/></param>
-        public void Info(string message, [CallerFilePath]string callingFile = "", [CallerMemberName]string callingMethod = "", [CallerLineNumber]int lineNumber = -1)
-            => LogMessage(LogEventLevel.INFORMATION, message, callingFile, callingMethod, lineNumber);
+        /// <param name="dynamicFormats">(optional) the list of <see cref="ILogFormatter"/> to use for log message formatting that are not a part of the logger</param>
+        public void Info(string message, ILogFormatter[]? dynamicFormats = null)
+            => LogMessage(LogEventLevel.INFORMATION, message, dynamicFormats);
         
         /// <summary>
         /// Logs a <see cref="LogEventLevel.WARNING"/> message with context info
         /// </summary>
         /// <param name="message">the message to log</param>
-        /// <param name="callingFile">the calling file via <see cref="CallerFilePathAttribute"/></param>
-        /// <param name="callingMethod">the calling method via <see cref="CallerMemberNameAttribute"/></param>
-        /// <param name="lineNumber">the calling line number via <see cref="CallerLineNumberAttribute"/></param>
-        public void Warning(string message, [CallerFilePath]string callingFile = "", [CallerMemberName]string callingMethod = "", [CallerLineNumber]int lineNumber = -1)
-            => LogMessage(LogEventLevel.WARNING, message, callingFile, callingMethod, lineNumber);
+        /// <param name="dynamicFormats">(optional) the list of <see cref="ILogFormatter"/> to use for log message formatting that are not a part of the logger</param>
+        public void Warning(string message, ILogFormatter[]? dynamicFormats = null)
+            => LogMessage(LogEventLevel.WARNING, message, dynamicFormats);
         
         /// <summary>
         /// Logs a <see cref="LogEventLevel.ERROR"/> message with context info
         /// </summary>
         /// <param name="message">the message to log</param>
-        /// <param name="callingFile">the calling file via <see cref="CallerFilePathAttribute"/></param>
-        /// <param name="callingMethod">the calling method via <see cref="CallerMemberNameAttribute"/></param>
-        /// <param name="lineNumber">the calling line number via <see cref="CallerLineNumberAttribute"/></param>
-        public void Error(string message, [CallerFilePath]string callingFile = "", [CallerMemberName]string callingMethod = "", [CallerLineNumber]int lineNumber = -1)
-            => LogMessage(LogEventLevel.ERROR, message, callingFile, callingMethod, lineNumber);
+        /// <param name="dynamicFormats">(optional) the list of <see cref="ILogFormatter"/> to use for log message formatting that are not a part of the logger</param>
+        public void Error(string message, ILogFormatter[]? dynamicFormats = null)
+            => LogMessage(LogEventLevel.ERROR, message, dynamicFormats);
         
         /// <summary>
         /// Logs a <see cref="LogEventLevel.FATAL"/> message with context info
         /// </summary>
         /// <param name="message">the message to log</param>
-        /// <param name="callingFile">the calling file via <see cref="CallerFilePathAttribute"/></param>
-        /// <param name="callingMethod">the calling method via <see cref="CallerMemberNameAttribute"/></param>
-        /// <param name="lineNumber">the calling line number via <see cref="CallerLineNumberAttribute"/></param>
-        public void Fatal(string message, [CallerFilePath]string callingFile = "", [CallerMemberName]string callingMethod = "", [CallerLineNumber]int lineNumber = -1)
-            => LogMessage(LogEventLevel.FATAL, message, callingFile, callingMethod, lineNumber);
+        /// <param name="dynamicFormats">(optional) the list of <see cref="ILogFormatter"/> to use for log message formatting that are not a part of the logger</param>
+        public void Fatal(string message, ILogFormatter[]? dynamicFormats = null)
+            => LogMessage(LogEventLevel.FATAL, message, dynamicFormats);
 
         /// <summary>
         /// Logs a message with context info and a given <see cref="LogEventLevel"/>
         /// </summary>
         /// <param name="level">the logging level</param>
         /// <param name="message">the message to log</param>
-        /// <param name="callingFile">the calling file via <see cref="CallerFilePathAttribute"/></param>
-        /// <param name="callingMethod">the calling method via <see cref="CallerMemberNameAttribute"/></param>
-        /// <param name="lineNumber">the calling line number via <see cref="CallerLineNumberAttribute"/></param>
-        public void LogMessage(LogEventLevel level, string message, [CallerFilePath]string callingFile = "", [CallerMemberName]string callingMethod = "", [CallerLineNumber]int lineNumber = -1) {
+        /// <param name="dynamicFormats">(optional) the list of <see cref="ILogFormatter"/> to use for log message formatting that are not a part of the logger</param>
+        public void LogMessage(LogEventLevel level, string message, ILogFormatter[]? dynamicFormats = null) {
             if (_disposed)
                 throw new ObjectDisposedException("Logger has been disposed");
 
@@ -133,30 +119,28 @@ namespace Lettuce.Log.Core {
                 return;
             }
 
-            string logMessage = FormatMessage(level, message, 
-                Path.GetFileNameWithoutExtension(callingFile), callingMethod, lineNumber);
+            string logMessage = FormatMessage(level, message, dynamicFormats);
 
             foreach(ILogDestination destination in _destinations) {
                 destination.LogMessage(logMessage, level);
             }
         }
 
-        private string FormatMessage(LogEventLevel level, string message, string file, string method, int line) {
+        private string FormatMessage(LogEventLevel level, string message, ILogFormatter[]? dynamicFormats = null) {
             const string MESSAGE_KEY = "{Message}";
             const string LEVEL_KEY = "{Level}";
-            const string FILE_KEY = "{File}";
-            const string METHOD_KEY = "{Method}";
-            const string LINE_KEY = "{Line}";
             
             string toReturn = _template;
 
             toReturn = toReturn.Replace(MESSAGE_KEY, message);
             toReturn = toReturn.Replace(LEVEL_KEY, level.ToString().PadLeft(11));
-            toReturn = toReturn.Replace(FILE_KEY, file);
-            toReturn = toReturn.Replace(METHOD_KEY, method);
-            toReturn = toReturn.Replace(LINE_KEY, line.ToString());
             foreach (ILogFormatter formatter in _formatters) {
                 toReturn = toReturn.Replace(formatter.FormatKey, formatter.GetFormat());
+            }
+            if (dynamicFormats != null) {
+                foreach(ILogFormatter formatter in dynamicFormats) {
+                    toReturn = toReturn.Replace(formatter.FormatKey, formatter.GetFormat());
+                }
             }
 
             return toReturn;

--- a/README.md
+++ b/README.md
@@ -24,27 +24,22 @@ Logger logger = new Logger(Log.DEFAULT_TEMPLATE);
 
 ### Logger
 
-`Logger` objects are where you log messages to certain `LogEventLevel`. Every log message is context aware, making using of [Microsoft's Caller Attributes](https://learn.microsoft.com/en-us/dotnet/csharp/language-reference/attributes/caller-information), where the calling file, method and line number are all passed with each log call.
+`Logger` objects are where you log messages to certain `LogEventLevel`. They are also the collection of `ILogFormatter` and `ILogDestination` objects.
 
-`Logger` objects are also the collection of `ILogFormatter` and `ILogDestination` objects.
-
-There is also a statically wrapped `Logger` called `Log` to allow for global logging around your systems without having to pass a `Logger` instance around
+There is also a statically wrapped `Logger` called `Log` to allow for quick and global logging around your systems without having to pass a `Logger` instance around
 
 
 ### ILogFormatter
 
 These objects format the log messages that come in. Each logger when constructing takes in a template for how the log message should be formatted before being fully logged. These templates are essentially keys to look in a string to insert the formatted string you want.
 
-For example, here is the default template: `{Level} ({File}/{Method} at {Line}) {Message}`
+For example, here is the default template: `{Level} {Message}`
 
 By default, `Logger` has the following formatters that get run for each log:
-| Template | Content |
-| -------- | --------------------- |
-| `{Message}`| The log message |
-| `{Level}` | The logging level of the message |
-| `{File}` | The calling file the log originated from |
-| `{Method}` | The calling method the log originated from |
-| `{Line}` | The line number the log originated from |
+| Template | Content
+| -------- | ---------------------
+| `{Message}`| The log message
+| `{Level}` | The logging level of the message
 
 
 ### ILogDestination


### PR DESCRIPTION
Removes the attributes that pass the context aware information like file name, method name, and line number. The idea being that this should be a opt-in/configurable thing about your logger, not something included by default. Plus, I would assume most people that care about obfuscation in any form, wouldnt take to kindly that it injects the absolute build path of your file unless you configure your `.csproj` in a certain way